### PR TITLE
[jsk_maps] Frame id cannot start with a '/' in tf2

### DIFF
--- a/jsk_maps/tools/publish_spot.l
+++ b/jsk_maps/tools/publish_spot.l
@@ -117,7 +117,7 @@
 
 (defun publish-spot ()
   (let* ((stamp (ros::time-now))
-         (header (instance std_msgs::header :init :stamp stamp :frame_id "/map"))
+         (header (instance std_msgs::header :init :stamp stamp :frame_id "map"))
          current-map-coords spots)
 
     ;; resolve /world -> /eng/2f


### PR DESCRIPTION
# What is this?

In noetic environment, the following error occurs.
This prevents the visualization marker visualizations.
```
Invalid argument "/map" passed to canTransform argument source_frame in tf2 frame_ids cannot start with a '/' like:
```
